### PR TITLE
fix call method fail

### DIFF
--- a/src/IdentityServer8/src/ResponseHandling/Default/DiscoveryResponseGenerator.cs
+++ b/src/IdentityServer8/src/ResponseHandling/Default/DiscoveryResponseGenerator.cs
@@ -331,7 +331,7 @@ public class DiscoveryResponseGenerator : IDiscoveryResponseGenerator
         }
 
         // custom entries
-        if (!Options.Discovery.CustomEntries.IsNullOrEmpty())
+        if (!Options.Discovery.CustomEntries.Any())
         {
             foreach ((string key, object value) in Options.Discovery.CustomEntries)
             {

--- a/src/IdentityServer8/src/ResponseHandling/Default/DiscoveryResponseGenerator.cs
+++ b/src/IdentityServer8/src/ResponseHandling/Default/DiscoveryResponseGenerator.cs
@@ -331,7 +331,7 @@ public class DiscoveryResponseGenerator : IDiscoveryResponseGenerator
         }
 
         // custom entries
-        if (!Options.Discovery.CustomEntries.Any())
+        if (!Options.Discovery.CustomEntries.EnumerableIsNullOrEmpty())
         {
             foreach ((string key, object value) in Options.Discovery.CustomEntries)
             {

--- a/src/IdentityServer8/src/Services/Default/DefaultKeyMaterialService.cs
+++ b/src/IdentityServer8/src/Services/Default/DefaultKeyMaterialService.cs
@@ -39,7 +39,7 @@ public class DefaultKeyMaterialService : IKeyMaterialService
     {
         if (_signingCredentialStores.Any())
         {
-            if (allowedAlgorithms != null && !allowedAlgorithms.Any())
+            if (allowedAlgorithms.EnumerableIsNullOrEmpty())
             {
                 return await _signingCredentialStores.First().GetSigningCredentialsAsync();
             }

--- a/src/IdentityServer8/src/Services/Default/DefaultKeyMaterialService.cs
+++ b/src/IdentityServer8/src/Services/Default/DefaultKeyMaterialService.cs
@@ -39,7 +39,7 @@ public class DefaultKeyMaterialService : IKeyMaterialService
     {
         if (_signingCredentialStores.Any())
         {
-            if (allowedAlgorithms.IsNullOrEmpty())
+            if (allowedAlgorithms != null && !allowedAlgorithms.Any())
             {
                 return await _signingCredentialStores.First().GetSigningCredentialsAsync();
             }


### PR DESCRIPTION
MethodAccessException: Attempt by method 'IdentityServer8.ResponseHandling.DiscoveryResponseGenerator+<CreateDiscoveryDocumentAsync>d__8.MoveNext()' to access method 'Microsoft.IdentityModel.Tokens.CollectionUtilities.IsNullOrEmpty<System.Collections.Generic.KeyValuePair`2<System.String,System.Object>>(System.Collections.Generic.IEnumerable`1<System.Collections.Generic.KeyValuePair`2<System.String,System.Object>>)' failed.

---
name: Bug report
about: call mehtod failed
labels: bug report
---

![image](https://github.com/user-attachments/assets/86e3ba4e-8fb3-448c-8f4e-82fc774eaa5e)
